### PR TITLE
Add woff2-Support

### DIFF
--- a/google-font-download
+++ b/google-font-download
@@ -62,7 +62,7 @@ usage() {
 		  -f FORMAT, --format=FORMAT
 		    Download the specified set of webfont formats from Google's
 		    servers. FORMAT is a comma-separated list of identifiers for
-		    webfont formats. Supported identifiers are eof, woff, svg,
+		    webfont formats. Supported identifiers are eof, woff, woff2, svg,
 		    and ttf. Additionally, the special value \`all' expands to
 		    all supported formats. The default is \`$format'. Note that
 		    you may not really need all formats. In most cases, WOFF is
@@ -198,12 +198,12 @@ fi
 declare -a formats
 if [ "$format" = "all" ]; then
 	# Deal with the special "all" value
-	formats=("eot" "woff" "svg" "ttf")
+	formats=("eot" "woff" "woff2" "svg" "ttf")
 else
 	IFS=', ' read -a formats <<< "$format"
 	for f in "${formats[@]}"; do
 		case "$f" in
-			eof|woff|svg|ttf)
+			eof|woff|woff2|svg|ttf)
 				;;
 			*)
 				err_exit "Unsupported font format \`${f}'"
@@ -246,6 +246,8 @@ declare -A useragent
 useragent[eot]='Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)'
 # shellcheck disable=SC2154
 useragent[woff]='Mozilla/5.0 (Windows NT 6.1; WOW64; rv:27.0) Gecko/20100101 Firefox/27.0'
+# shellcheck disable=SC2154
+useragent[woff2]='Mozilla/5.0 (Windows NT 6.1; WOW64; rv:38.0) Gecko/20100101 Firefox/38.0'
 # shellcheck disable=SC2154
 useragent[svg]='Mozilla/4.0 (iPad; CPU OS 4_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/4.1 Mobile/9A405 Safari/7534.48.3'
 # shellcheck disable=SC2154
@@ -350,6 +352,9 @@ for family in "${families[@]}"; do
 				;;
 			woff)
 				printf >>"$css" "\t\turl('%s') format('woff')%s\n" "${fontnameescaped}.$uakey" "${terminator}"
+				;;
+			woff)
+				printf >>"$css" "\t\turl('%s') format('woff2')%s\n" "${fontnameescaped}.$uakey" "${terminator}"
 				;;
 			ttf)
 				printf >>"$css" "\t\turl('%s') format('truetype')%s\n" "${fontnameescaped}.$uakey" "${terminator}"


### PR DESCRIPTION
Since newer Versions of Firefox use woff and try to get them, this adds more and more 404s to server logs.
